### PR TITLE
[refs #0003] Move styles to much higher up in the DOM

### DIFF
--- a/components/_footer.html
+++ b/components/_footer.html
@@ -9,9 +9,7 @@
 		<li>Credits</li>
 	</ul> -->
 </footer>
-<link rel="stylesheet" href="/css/compiled.css">
 <script src="/js/bundle.min.js" async></script>
-<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700' rel='stylesheet' type='text/css'>
 
 </body>
 </html>

--- a/components/_head.html
+++ b/components/_head.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700' rel='stylesheet' type='text/css'>
+	<link rel="stylesheet" href="/css/compiled.css">
 	<title>Max Stoiber - Frontend Development, HTML5, CSS3, JavaScript</title>
 	<meta name="description" content="Freelance Frontend Developer, proficient in HTML, CSS and JavaScript. Focussed on web application development." />
 	<meta name="keywords" content="HTML, CSS, JavaScript, HTML5, CSS3, JS, jQuery, Frontend Development, Web Development, Web Design, Development, Frontend" />


### PR DESCRIPTION
As per #3, this PR will improve performance by allowing CSSOM (and thus rendering) to happen much sooner, and will avoid the FOUC caused by the browser rendering HTML before it knows about the CSS.